### PR TITLE
fix(drawing routines): setPixels() bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiteLED
 
-## v1.2.0
+## v1.2.1
 
 ## What is it?
 
@@ -534,6 +534,11 @@ Full credit and recognition to Uncle Rus and the team that supplies and supports
 ## _
 
 ## Revision History
+
+### v1.2.1
+
+- Bug fix: `setPixels()`, with `crgb_t` data, would not flush the buffer to the LED's when the parameter `show` was `true`.<br>
+- Bug fix: `setPixels()`, with `rgb_t` data, would always start at `0` regardless of the `start` value provided.
 
 ### v1.2.0
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LiteLED
-version=1.2.0
+version=1.2.1
 author=Xylopyrographer
 maintainer=Xylopyrographer <xylopyrographer@gmail.com>
 sentence=Light weight library for driving one or more WS2812B, SK6812, APA106, SM16703 RGB LED strips.

--- a/src/LiteLED.cpp
+++ b/src/LiteLED.cpp
@@ -56,7 +56,7 @@ esp_err_t LiteLED::setPixel( size_t num, crgb_t color, bool show ) {
 }
 
 esp_err_t LiteLED::setPixels( size_t start, size_t len, rgb_t* data, bool show ) {
-    esp_err_t _res = led_strip_set_pixels( &theStrip, ( size_t )0, ( size_t )theStrip.length, data );
+    esp_err_t _res = led_strip_set_pixels( &theStrip, start, len, data );
     if ( _res != ESP_OK )
         return _res;
     if ( show )


### PR DESCRIPTION
Fixes a couple of bugs in the `setPixels()` routines. Refer to the Revision History section of the README.md document.