### PR TITLE
Fixed a few warnings and changed debug log to verbose

### DIFF
--- a/src/llrmt.h
+++ b/src/llrmt.h
@@ -194,7 +194,6 @@ IRAM_ATTR static size_t led_encoder_cb( const void* data, size_t data_size,
 
 esp_err_t led_strip_init( led_strip_t *strip ) {
     /* initializes all structures and variables required for the library */
-    esp_err_t res = ESP_OK;
     if ( !( strip && strip->length > 0 && strip->type < LED_STRIP_TYPE_MAX ) ) {
         log_e( "led_strip_init(): invalid aguments." );
         return ESP_ERR_INVALID_ARG;

--- a/src/llrmt.h
+++ b/src/llrmt.h
@@ -131,8 +131,8 @@ static const led_params_t led_params[] = {
 // led_strip_cfg_t stripCfg;
 color_order_t custom_color_order = ORDER_GRB;
 bool use_custom_color_order = false;
-char *col_ord[] = { "order_rgb", "order_rbg", "order_grb", "order_gbr", "order_brg", "order_bgr", "order_max" };
-char *led_type[] = { "ws2812", "ws2812_rgb", "sk6812", "apa106", "sm167O3" };
+const char *col_ord[] = { "order_rgb", "order_rbg", "order_grb", "order_gbr", "order_brg", "order_bgr", "order_max" };
+const char *led_type[] = { "ws2812", "ws2812_rgb", "sk6812", "apa106", "sm167O3" };
 
 void led_strip_debug_dump( led_strip_t *strip );
 

--- a/src/llrmt.h
+++ b/src/llrmt.h
@@ -218,13 +218,13 @@ esp_err_t led_strip_init( led_strip_t *strip ) {
             .io_od_mode = 0,            /* open drain */
         }
     };
-    log_d( "Defining the led encoder configuration." );
+    log_v( "Defining the led encoder configuration." );
     strip->stripCfg.led_encoder_cfg = {
         led_encoder_cb,                         /* the led encoder function */
         strip,                                  /* arg's for the led encoder function */
         ( size_t )LL_ENCODER_MIN_CHUNK_SIZE,    /* explcitly set - default is 64 */
     };
-    log_d( "Setting the RMT transmit configuration." );
+    log_v( "Setting the RMT transmit configuration." );
     strip->stripCfg.led_tx_config = {
         .loop_count = 0,
         .flags = {
@@ -232,7 +232,7 @@ esp_err_t led_strip_init( led_strip_t *strip ) {
             .queue_nonblocking = 0,
         }
     };
-    log_d( "RMT driver configuration complete. Debug dump..." );
+    log_v( "RMT driver configuration complete. Debug dump..." );
     led_strip_debug_dump( strip );
     return ESP_OK;
 }
@@ -241,14 +241,14 @@ esp_err_t led_strip_init_modify( led_strip_t *strip, ll_dma_t use_dma, ll_priori
     /* sets user defined DMA and interrupt priority settings for the LED strip */
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL( 5, 1, 2 )
     strip->stripCfg.led_chan_config.intr_priority = priority;    /* callback interrupt priority, default is 0 - gaurd is for compatibility with earlier versions of esp32-idf */
-    log_d( "led_strip_init_modify(): Setting the RMT interrupt priority to %d.", priority );
+    log_v( "led_strip_init_modify(): Setting the RMT interrupt priority to %d.", priority );
 #endif
 #if LL_DMA_SUPPORT
     strip->stripCfg.led_chan_config.flags.with_dma = use_dma;    /* use DMA (or not) */
-    log_d( "led_strip_init_modify(): Setting the RMT DMA usage to %s.", use_dma ? "ON" : "OFF" );
+    log_v( "led_strip_init_modify(): Setting the RMT DMA usage to %s.", use_dma ? "ON" : "OFF" );
     if ( use_dma ) {
         strip->stripCfg.led_chan_config.mem_block_symbols = ( size_t )LL_MEM_BLOCK_SIZE_DMA;   /* RMT DMA lets us use a large block size */
-        log_d( "led_strip_init_modify(): Setting the RMT DMA memory block size to %d.", strip->stripCfg.led_chan_config.mem_block_symbols );
+        log_v( "led_strip_init_modify(): Setting the RMT DMA memory block size to %d.", strip->stripCfg.led_chan_config.mem_block_symbols );
     }
 #else
     strip->stripCfg.led_chan_config.flags.with_dma = DMA_DEFAULT;  /* turn off RMT DMA on ESP32 models that don't support it  */
@@ -274,12 +274,12 @@ esp_err_t led_strip_install( led_strip_t *strip ) {
         log_e( "rmt_new_simple_encode(): failed to create LED encoder - %s.", esp_err_to_name( res ) );
         return res;
     }
-    log_d( "Enabling the RMT TX channel." );
+    log_v( "Enabling the RMT TX channel." );
     if ( ( res = rmt_enable( strip->stripCfg.led_chan ) ) != ESP_OK ) {
         log_e( "rmt_enable(): failed to enable RMT TX channel - %s.", esp_err_to_name( res ) );
         return res;
     }
-    log_d( "LED strip installed. Debug dump..." );
+    log_v( "LED strip installed. Debug dump..." );
     led_strip_debug_dump( strip );
     return res;
 }
@@ -536,8 +536,8 @@ esp_err_t led_strip_set_color_order( led_strip_t *strip, color_order_t led_order
     /* sets the color order of the LED's in the strip */
     custom_color_order = led_order;
     use_custom_color_order = true; // Set the custom colour order flag
-    log_d( "led_strip_set_color_order(): Setting custom color order to %s.", col_ord[ custom_color_order ] );
-    log_d( "led_strip_set_color_order(): use_custom_color_order set to %s.", use_custom_color_order ? "true" : "false" );
+    log_v( "led_strip_set_color_order(): Setting custom color order to %s.", col_ord[ custom_color_order ] );
+    log_v( "led_strip_set_color_order(): use_custom_color_order set to %s.", use_custom_color_order ? "true" : "false" );
     return ESP_OK;
 }
 
@@ -545,60 +545,60 @@ esp_err_t led_strip_set_default_color_order( led_strip_t *strip ) {
     /* sets the color order of the LED's in the strip to the value defined by the LED type paramaters */
     custom_color_order = led_params[ strip->type ].order;
     use_custom_color_order = false; // reset the custom colour order flag
-    log_d( "led_strip_set_default_color_order(): Setting custom color order to %s.", col_ord[ custom_color_order ] );
-    log_d( "led_strip_set_default_color_order(): use_custom_color_order set to %s.", use_custom_color_order ? "true" : "false" );
+    log_v( "led_strip_set_default_color_order(): Setting custom color order to %s.", col_ord[ custom_color_order ] );
+    log_v( "led_strip_set_default_color_order(): use_custom_color_order set to %s.", use_custom_color_order ? "true" : "false" );
     return ESP_OK;
 }
 
 void led_strip_debug_dump( led_strip_t *strip ) {
     /* dumps the LED strip configuration data to the serial monitor */
     if ( strip ) {
-        log_d( "" );
-        log_d( "=============================================" );
-        log_d( "LED strip object at: %p", strip );
-        log_d( "    type: %s", led_type[ strip->type ] );
-        log_d( "    is_rgbw: %d", strip->is_rgbw );
-        log_d( "    auto_w: %d", strip->auto_w );
-        log_d( "    brightness: %d", strip->brightness );
-        log_d( "    bright_act: %d", strip->bright_act );
-        log_d( "    length: %d", strip->length );
-        log_d( "    gpio: %d", strip->gpio );
-        log_d( "    buf: %p", strip->buf );
-        log_d( "    buf color size: %d", COLOR_SIZE( strip ) );
-        log_d( "    buf bytes: %d", PIXEL_SIZE( strip ) );
-        log_d( "    led_chan_config at: %p", &strip->stripCfg.led_chan_config );
-        log_d( "        .gpio_num: %d", strip->stripCfg.led_chan_config.gpio_num );
-        log_d( "        .clk_src: %d", strip->stripCfg.led_chan_config.clk_src );
-        log_d( "        .resolution_hz: %d", strip->stripCfg.led_chan_config.resolution_hz );
-        log_d( "        .mem_block_symbols: %d", strip->stripCfg.led_chan_config.mem_block_symbols );
-        log_d( "        .trans_queue_depth: %d", strip->stripCfg.led_chan_config.trans_queue_depth );
+        log_v( "" );
+        log_v( "=============================================" );
+        log_v( "LED strip object at: %p", strip );
+        log_v( "    type: %s", led_type[ strip->type ] );
+        log_v( "    is_rgbw: %d", strip->is_rgbw );
+        log_v( "    auto_w: %d", strip->auto_w );
+        log_v( "    brightness: %d", strip->brightness );
+        log_v( "    bright_act: %d", strip->bright_act );
+        log_v( "    length: %d", strip->length );
+        log_v( "    gpio: %d", strip->gpio );
+        log_v( "    buf: %p", strip->buf );
+        log_v( "    buf color size: %d", COLOR_SIZE( strip ) );
+        log_v( "    buf bytes: %d", PIXEL_SIZE( strip ) );
+        log_v( "    led_chan_config at: %p", &strip->stripCfg.led_chan_config );
+        log_v( "        .gpio_num: %d", strip->stripCfg.led_chan_config.gpio_num );
+        log_v( "        .clk_src: %d", strip->stripCfg.led_chan_config.clk_src );
+        log_v( "        .resolution_hz: %d", strip->stripCfg.led_chan_config.resolution_hz );
+        log_v( "        .mem_block_symbols: %d", strip->stripCfg.led_chan_config.mem_block_symbols );
+        log_v( "        .trans_queue_depth: %d", strip->stripCfg.led_chan_config.trans_queue_depth );
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 2)
-        log_d( "        .intr_priority: %d", strip->stripCfg.led_chan_config.intr_priority );
+        log_v( "        .intr_priority: %d", strip->stripCfg.led_chan_config.intr_priority );
 #endif
-        log_d( "        .flags" );
-        log_d( "            .invert_out: %d", strip->stripCfg.led_chan_config.flags.invert_out );
-        log_d( "            .with_dma: %d", strip->stripCfg.led_chan_config.flags.with_dma );
-        log_d( "            .io_loop_back: %d", strip->stripCfg.led_chan_config.flags.io_loop_back );
-        log_d( "            .io_od_mode: %d", strip->stripCfg.led_chan_config.flags.io_od_mode );
-        log_d( "    led_tx_config:" );
-        log_d( "        .loop_count: %d", strip->stripCfg.led_tx_config.loop_count );
-        log_d( "        .flags" );
-        log_d( "            .queue_nonblocking: %d", strip->stripCfg.led_tx_config.flags.queue_nonblocking );
-        log_d( "            .eot_level: %d", strip->stripCfg.led_tx_config.flags.eot_level );
-        log_d( "    led_chan: %p", strip->stripCfg.led_chan );
-        log_d( "    led_encoder_cfg: %p", strip->stripCfg.led_encoder_cfg );
-        log_d( "    led_encoder: %p", strip->stripCfg.led_encoder );
-        log_d( "    led_encoder chunk size: %d", strip->stripCfg.led_encoder_cfg.min_chunk_size );
-        log_d( "    -----------------------------------------" );
-        log_d( "    led color order: %s", col_ord[ led_params[ strip->type ].order ] );
-        log_d( "    led custom color order: %s", col_ord[ custom_color_order ] );
-        log_d( "    led use custom color order: %s", use_custom_color_order ? "true" : "false" );
-        log_d( "LED strip object dump complete" );
-        log_d( "=============================================" );
-        log_d( "" );
+        log_v( "        .flags" );
+        log_v( "            .invert_out: %d", strip->stripCfg.led_chan_config.flags.invert_out );
+        log_v( "            .with_dma: %d", strip->stripCfg.led_chan_config.flags.with_dma );
+        log_v( "            .io_loop_back: %d", strip->stripCfg.led_chan_config.flags.io_loop_back );
+        log_v( "            .io_od_mode: %d", strip->stripCfg.led_chan_config.flags.io_od_mode );
+        log_v( "    led_tx_config:" );
+        log_v( "        .loop_count: %d", strip->stripCfg.led_tx_config.loop_count );
+        log_v( "        .flags" );
+        log_v( "            .queue_nonblocking: %d", strip->stripCfg.led_tx_config.flags.queue_nonblocking );
+        log_v( "            .eot_level: %d", strip->stripCfg.led_tx_config.flags.eot_level );
+        log_v( "    led_chan: %p", strip->stripCfg.led_chan );
+        log_v( "    led_encoder_cfg: %p", strip->stripCfg.led_encoder_cfg );
+        log_v( "    led_encoder: %p", strip->stripCfg.led_encoder );
+        log_v( "    led_encoder chunk size: %d", strip->stripCfg.led_encoder_cfg.min_chunk_size );
+        log_v( "    -----------------------------------------" );
+        log_v( "    led color order: %s", col_ord[ led_params[ strip->type ].order ] );
+        log_v( "    led custom color order: %s", col_ord[ custom_color_order ] );
+        log_v( "    led use custom color order: %s", use_custom_color_order ? "true" : "false" );
+        log_v( "LED strip object dump complete" );
+        log_v( "=============================================" );
+        log_v( "" );
     }
     else {
-        log_d( "LED strip object is NULL." );
+        log_v( "LED strip object is NULL." );
     }
 }
 


### PR DESCRIPTION
While using your library there were some warnings that appeared. 
One about strings not being const and the other about an unused return variable. 

Also changed debug to verbose logging.