### PR TITLE
Fix: guard llparlio.h include behind SOC_PARLIO_SUPPORTED (v3.1.1)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LiteLED
-version=3.1.0
+version=3.1.1
 author=Xylopyrographer
 maintainer=Xylopyrographer <xylopyrographer@gmail.com>
 sentence=High performance library for driving one or more WS2812 and other types of RGB LED strips via the RMT or PARLIO peripheral.

--- a/src/LiteLEDpio.cpp
+++ b/src/LiteLEDpio.cpp
@@ -6,7 +6,6 @@
 
 #include <Arduino.h>
 #include "LiteLED.h"
-#include "llparlio.h"
 #include "ll_strip_pixels.h"
 
 #ifdef __cplusplus
@@ -17,7 +16,12 @@ extern "C" {
 }
 #endif
 
+#ifndef SOC_PARLIO_SUPPORTED
+    #define SOC_PARLIO_SUPPORTED 0
+#endif
+
 #if SOC_PARLIO_SUPPORTED
+#include "llparlio.h"
 
 // -------------------------------------------------------------------------
 // Peripheral Manager bus type for PARLIO TX.

--- a/src/LiteLEDpioGroup.cpp
+++ b/src/LiteLEDpioGroup.cpp
@@ -15,7 +15,6 @@
 
 #include <Arduino.h>
 #include "LiteLED.h"
-#include "llparlio.h"
 #include "ll_strip_pixels.h"
 
 #ifdef __cplusplus
@@ -26,7 +25,12 @@ extern "C" {
 }
 #endif
 
+#ifndef SOC_PARLIO_SUPPORTED
+    #define SOC_PARLIO_SUPPORTED 0
+#endif
+
 #if SOC_PARLIO_SUPPORTED
+#include "llparlio.h"
 
 // -------------------------------------------------------------------------
 // Peripheral Manager bus type


### PR DESCRIPTION
## Problem

`LiteLEDpio.cpp` and `LiteLEDpioGroup.cpp` unconditionally `#include "llparlio.h"`, which fires a hard `#error` on any ESP32 target that lacks a PARLIO peripheral (e.g. ESP32-S3, ESP32, ESP32-S2). This caused a compile failure even when user code only uses the RMT-based `LiteLED` class.

## Fix

Moved the `#include "llparlio.h"` inside the existing `#if SOC_PARLIO_SUPPORTED` block in both source files, so the include — and the error — is only reached on targets that actually have PARLIO hardware.

## Testing

Built against three environments:
- `seeed_xiao_esp32c6` (PARLIO + RMT) — ✅ PARLIO sketch
- `seeed_xiao_esp32c6` (PARLIO + RMT) — ✅ RMT sketch  
- `esp32-s3-devkitc1-n4r2` (RMT only, no PARLIO) — ✅ RMT sketch (previously failed)